### PR TITLE
Add theme support using next-themes and refactor layout component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
+import { ThemeProvider } from 'next-themes';
 import React from 'react';
 
 const inter = localFont({
@@ -30,11 +31,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${inter.className} ${spaceGrotesk.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/context/Theme.tsx
+++ b/context/Theme.tsx
@@ -1,0 +1,12 @@
+'use client';
+import {
+  ThemeProvider as NextThemeProvider,
+  ThemeProviderProps,
+} from 'next-themes';
+import React from 'react';
+
+const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
+  return <NextThemeProvider {...props}>{children}</NextThemeProvider>;
+};
+
+export default ThemeProvider;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "eslint-plugin-tailwindcss": "^3.17.5",
         "lint": "^0.8.19",
         "next": "15.0.2",
+        "next-themes": "^0.4.3",
         "react": "19.0.0-rc-02c0e824-20241028",
         "react-dom": "19.0.0-rc-02c0e824-20241028",
         "tailwindcss-animate": "^1.0.7"
@@ -4970,6 +4971,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.3.tgz",
+      "integrity": "sha512-nG84VPkTdUHR2YeD89YchvV4I9RbiMAql3GiLEQlPvq1ioaqPaIReK+yMRdg/zgiXws620qS1rU30TiWmmG9lA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eslint-plugin-tailwindcss": "^3.17.5",
     "lint": "^0.8.19",
     "next": "15.0.2",
+    "next-themes": "^0.4.3",
     "react": "19.0.0-rc-02c0e824-20241028",
     "react-dom": "19.0.0-rc-02c0e824-20241028",
     "tailwindcss-animate": "^1.0.7"
@@ -30,5 +31,10 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
+  },
+  "packageManager": "npm@10.7.0",
+  "overrides": {
+    "react": "$react",
+    "react-dom": "$react-dom"
   }
 }


### PR DESCRIPTION
This pull request introduces a new theme provider and updates the project dependencies accordingly. The most important changes include adding the `next-themes` package, integrating the theme provider into the application's layout, and creating a custom theme provider component.

### Theme Integration:

* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR4): Added the `ThemeProvider` from `next-themes` to the root layout, enabling system-based theming and disabling transitions on theme change. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR4) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL33-R45)
* [`context/Theme.tsx`](diffhunk://#diff-f4cc4e75fa7e1e68838d88845ec64e22a95ccdc78f98f7b7e853227da2685e32R1-R12): Created a custom `ThemeProvider` component that wraps the `NextThemeProvider` from `next-themes`.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17): Added the `next-themes` package to the dependencies and updated the package manager to `npm@10.7.0`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34-R38)