### PR TITLE
Add QuestionForm component and validation schema for asking questions

### DIFF
--- a/app/(root)/ask-question/page.tsx
+++ b/app/(root)/ask-question/page.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 
+import QuestionForm from '@/components/forms/QuestionForm';
+
 const AskAQuestion = () => {
-  return <div>AskAQuestion</div>;
+  return (
+    <>
+      <h1 className="h1-bold text-dark100_light900"> Ask a public question</h1>
+      <div className="mt-9">
+        <QuestionForm />
+      </div>
+    </>
+  );
 };
 
 export default AskAQuestion;

--- a/components/forms/QuestionForm.tsx
+++ b/components/forms/QuestionForm.tsx
@@ -1,0 +1,117 @@
+'use client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+
+import { AskQuestionSchema } from '@/lib/validation';
+
+import { Button } from '../ui/button';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '../ui/form';
+import { Input } from '../ui/input';
+
+const QuestionForm = () => {
+  const form = useForm({
+    resolver: zodResolver(AskQuestionSchema),
+    defaultValues: {
+      title: '',
+      content: '',
+      tags: [],
+    },
+  });
+
+  const handleCreateQuestion = () => {};
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex w-full flex-col gap-10"
+        onSubmit={form.handleSubmit(handleCreateQuestion)}
+      >
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem className="flex w-full flex-col">
+              <FormLabel className="paragraph-semibold text-dark400_light800">
+                Question Title <span className="text-primary-500">*</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  className="paragraph-regular background-light700_dark300 light-border-2 text-dark300_light700 no-focus min-h-[56px] border"
+                />
+              </FormControl>
+              <FormDescription className="body-regular mt-2.5 text-light-500">
+                Be specific and imagine you’re asking a question to another
+                person
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="content"
+          render={({ field }) => (
+            <FormItem className="flex w-full flex-col">
+              <FormLabel className="paragraph-semibold text-dark400_light800">
+                Detailed explanation of your problem{' '}
+                <span className="text-primary-500">*</span>
+              </FormLabel>
+              <FormControl>Editor</FormControl>
+              <FormDescription className="body-regular mt-2.5 text-light-500">
+                Introduce the problem and expand. On what you have put in the
+                title.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="tags"
+          render={({ field }) => (
+            <FormItem className="flex w-full flex-col gap-3">
+              <FormLabel className="paragraph-semibold text-dark400_light800">
+                Tags <span className="text-primary-500">*</span>
+              </FormLabel>
+              <FormControl>
+                <div>
+                  <Input
+                    {...field}
+                    placeholder="Add tags ..."
+                    className="paragraph-regular background-light700_dark300 light-border-2 text-dark300_light700 no-focus min-h-[56px] border"
+                  />
+                  Tags
+                </div>
+              </FormControl>
+              <FormDescription className="body-regular mt-2.5 text-light-500">
+                Add up to 3 tags to describe what your question is about. You
+                need to press enter to add a tag
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="mt-16 flex justify-end">
+          <Button
+            type="submit"
+            className="primary-gradient w-fit !text-light-900"
+          >
+            Ask A Question
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};
+
+export default QuestionForm;

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -48,3 +48,22 @@ export const SignUpSchema = z.object({
       message: 'Password must contain at least one special character.',
     }),
 });
+
+export const AskQuestionSchema = z.object({
+  title: z
+    .string()
+    .min(5, { message: 'Title is required.' })
+    .max(100, { message: 'Title cannot exceed 100 characters.' }),
+
+  content: z.string().min(1, { message: 'Body is required.' }),
+
+  tags: z
+    .array(
+      z
+        .string()
+        .min(1, { message: 'Tag is required.' })
+        .max(30, { message: 'Tag cannot exceed 30 characters.' }),
+    )
+    .min(1, { message: 'At least one tag is required.' })
+    .max(3, { message: 'Cannot add more than 5 tags.' }),
+});


### PR DESCRIPTION
This pull request introduces a new feature to handle the "Ask a Question" functionality, including a form for users to submit their questions. The changes span multiple files, adding a new form component, integrating it into the page, and defining validation schemas.

Key changes include:

### New Feature Implementation:

* [`app/(root)/ask-question/page.tsx`](diffhunk://#diff-a44acc34e2dc194254520cf50cbdd998031719666d44180d6e68f7d5b676c974R3-R13): Integrated the `QuestionForm` component into the "Ask a Question" page, replacing the placeholder text with the form and a header.

### Form Component:

* [`components/forms/QuestionForm.tsx`](diffhunk://#diff-fa8351825960647fd6086511fe8a3163d84985bd921ed121bc904f2ad20ce349R1-R117): Added the `QuestionForm` component, which uses `react-hook-form` and `zod` for form handling and validation. The form includes fields for the question title, content, and tags, along with appropriate labels, descriptions, and validation messages.

### Validation Schema:

* [`lib/validation.ts`](diffhunk://#diff-4dd83f100006aaa41a4fdf091876a4dd2eee068706221a21c9098ba7164b4e21R51-R69): Defined the `AskQuestionSchema` using `zod` to enforce validation rules for the question title, content, and tags. This schema ensures that titles are between 5 and 100 characters, content is not empty, and tags are between 1 and 30 characters with a maximum of 3 tags.