### PR TITLE
Implement POST endpoint for account retrieval with validation and error handling

### DIFF
--- a/app/api/accounts/provider/route.ts
+++ b/app/api/accounts/provider/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+
+import Account from '@/database/account.model';
+import handleError from '@/lib/handlers/error';
+import { NotFoundError, ValidationError } from '@/lib/http-errors';
+import { AccountSchema } from '@/lib/validation';
+import { APIErrorResponse } from '@/types/global';
+
+export async function POST(request: Request) {
+  const { providerAccountId } = await request.json();
+
+  try {
+    const validatedData = AccountSchema.partial().safeParse({
+      providerAccountId,
+    });
+
+    if (!validatedData.success)
+      throw new ValidationError(validatedData.error.flatten().fieldErrors);
+
+    const account = await Account.findOne({ providerAccountId });
+
+    if (!account) throw new NotFoundError('Account');
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: account,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return handleError(error, 'api') as APIErrorResponse;
+  }
+}


### PR DESCRIPTION
This pull request includes a new POST endpoint to handle account retrieval based on a provider account ID. The most important changes are the addition of the new endpoint and the associated error handling.

New endpoint addition:

* [`app/api/accounts/provider/route.ts`](diffhunk://#diff-1cf63234a355563046e4feb1f5792b17f1e3da52adc4db74203ac575514f7a79R1-R34): Added a POST endpoint to retrieve account information based on the `providerAccountId`. The endpoint validates the input, checks for the existence of the account, and handles errors appropriately.