### PR TITLE
Implement edit and get question functionalities with validation and session handling

### DIFF
--- a/database/tag.model.ts
+++ b/database/tag.model.ts
@@ -1,10 +1,11 @@
-import { model, models, Schema } from 'mongoose';
+import { model, models, Schema, Document } from 'mongoose';
 
 export interface ITag {
   name: string;
   questions: number;
 }
 
+export interface ITagDoc extends ITag, Document {}
 const TagSchema = new Schema<ITag>(
   {
     name: { type: String, required: true, unique: true },

--- a/lib/actions/question.action.ts
+++ b/lib/actions/question.action.ts
@@ -1,10 +1,12 @@
 'use server';
 
+import { error } from 'console';
+
 import mongoose from 'mongoose';
 
 import Question from '@/database/question.model';
 import TagQuestion from '@/database/tag-question.model';
-import Tag from '@/database/tag.model';
+import Tag, { ITagDoc } from '@/database/tag.model';
 import {
   ActionResponse,
   ErrorResponse,
@@ -13,7 +15,11 @@ import {
 
 import action from '../handlers/action';
 import handleError from '../handlers/error';
-import { AskQuestionSchema } from '../validation';
+import {
+  AskQuestionSchema,
+  EditQuestionSchema,
+  GetQuestionsSchema,
+} from '../validation';
 
 export async function createQuestion(
   params: CreateQuestionParams,
@@ -82,5 +88,138 @@ export async function createQuestion(
     return handleError(error) as ErrorResponse;
   } finally {
     session.endSession();
+  }
+}
+
+export async function editQuestion(
+  params: EditQuestionParams,
+): Promise<ActionResponse<QuestionType>> {
+  const validationResult = await action({
+    params,
+    schema: EditQuestionSchema,
+    authorize: true,
+  });
+
+  if (validationResult instanceof Error) {
+    return handleError(validationResult) as ErrorResponse;
+  }
+
+  const { title, content, tags, questionId } = validationResult.params!;
+  const userId = validationResult?.session?.user?.id;
+  const session = await mongoose.startSession();
+
+  session.startTransaction();
+
+  try {
+    const question = await Question.findById(questionId).populate('tags');
+
+    if (!question) {
+      throw new Error('Question not found');
+    }
+
+    if (!question.author.equals(userId)) {
+      throw new Error('Unauthorized');
+    }
+
+    if (question.title !== title || question.content !== content) {
+      question.title = title;
+      question.content = content;
+      await question.save();
+    }
+
+    const tagsToAdd = tags.filter(
+      (tag) => !question.tags.includes(tag.toLowerCase()),
+    );
+    const tagsToRemove = question.tags.filter(
+      (tag: ITagDoc) => !tags.includes(tag.name.toLowerCase()),
+    );
+
+    const newTagDocuments = [];
+
+    if (tagsToAdd.length > 0) {
+      for (const tag of tagsToAdd) {
+        const existingTag = await Tag.findOneAndUpdate(
+          { name: { $regex: new RegExp(`^${tag}$`, 'i') } },
+          { $setOnInsert: { name: tag }, $inc: { questions: 1 } },
+          { upsert: true, new: true, session },
+        );
+        if (existingTag) {
+          newTagDocuments.push({
+            tag: existingTag._id,
+            question: questionId,
+          });
+
+          question.tags.push(existingTag);
+        }
+      }
+    }
+
+    if (tagsToRemove.length > 0) {
+      const tagIdsToRemove = tagsToRemove.map((tag: ITagDoc) => tag._id);
+
+      await Tag.updateMany(
+        { _id: { $in: tagIdsToRemove } },
+        { $inc: { questions: -1 } },
+        { session },
+      );
+
+      await TagQuestion.deleteMany(
+        { tag: { $in: tagIdsToRemove }, question: questionId },
+        { session },
+      );
+
+      question.tags = question.tags.filter(
+        (tagId: mongoose.Types.ObjectId) => !tagsToRemove.includes(tagId),
+      );
+    }
+
+    if (newTagDocuments.length > 0) {
+      await TagQuestion.insertMany(newTagDocuments, { session });
+    }
+
+    await question.save();
+
+    await session.commitTransaction();
+
+    return {
+      success: true,
+      data: JSON.parse(JSON.stringify(question)),
+    };
+  } catch (error) {
+    await session.abortTransaction();
+    return handleError(error) as ErrorResponse;
+  } finally {
+    session.endSession();
+  }
+}
+
+export async function getQuestion(
+  params: getQuestionsParams,
+): Promise<ActionResponse<QuestionType>> {
+  const validationResult = await action({
+    params,
+    schema: GetQuestionsSchema,
+    authorize: true,
+  });
+
+  if (validationResult instanceof Error) {
+    return handleError(validationResult) as ErrorResponse;
+  }
+
+  const { questionId } = validationResult.params!;
+
+  try {
+    const question = await Question.findById(questionId).populate('tags');
+
+    if (!question) {
+      throw new Error('Question not found');
+    }
+
+    return {
+      success: true,
+      data: JSON.parse(JSON.stringify(question)),
+    };
+  } catch {
+    return handleError(error) as ErrorResponse;
   }
 }

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -125,3 +125,11 @@ export const SignInWithOAuthSchema = z.object({
     image: z.string().url('Invalid image URL').optional(),
   }),
 });
+
+export const EditQuestionSchema = AskQuestionSchema.extend({
+  questionId: z.string().min(1, { message: 'Question ID is required.' }),
+});
+
+export const GetQuestionsSchema = z.object({
+  questionId: z.string().min(1, { message: 'Question ID is required.' }),
+});

--- a/types/action.d.ts
+++ b/types/action.d.ts
@@ -21,3 +21,11 @@ interface CreateQuestionParams {
   content: string;
   tags: string[];
 }
+
+interface EditQuestionParams extends CreateQuestionParams {
+  questionId: string;
+}
+
+interface getQuestionsParams {
+  questionId: string;
+}


### PR DESCRIPTION
This pull request introduces several changes to the `database`, `lib/actions`, and `lib/validation` files to support new functionalities for editing and retrieving questions. The key changes include the addition of new schemas, methods, and interfaces to handle these operations.

### Enhancements to Question Actions:

* [`lib/actions/question.action.ts`](diffhunk://#diff-b62375164edd30877d1fe114f89163d9236ec1f4e85eb51b3a7e9f67c4561f39R93-R225): Added `editQuestion` and `getQuestion` methods to handle editing and retrieving questions, respectively. These methods include validation, authorization, and transaction management for updating question details and associated tags.

### Schema Updates:

* [`lib/validation.ts`](diffhunk://#diff-4dd83f100006aaa41a4fdf091876a4dd2eee068706221a21c9098ba7164b4e21R128-R135): Introduced `EditQuestionSchema` and `GetQuestionsSchema` to validate the parameters for editing and retrieving questions.

### Interface and Import Adjustments:

* [`database/tag.model.ts`](diffhunk://#diff-344d2531e5a73842365b49375601d29cdc49e0b29d4563cc175efe0859370ac3L1-R8): Added `ITagDoc` interface extending `ITag` and `Document` to represent a tag document in MongoDB.
* [`lib/actions/question.action.ts`](diffhunk://#diff-b62375164edd30877d1fe114f89163d9236ec1f4e85eb51b3a7e9f67c4561f39R3-R9): Updated imports to include the new `ITagDoc` interface and additional schemas for question actions. [[1]](diffhunk://#diff-b62375164edd30877d1fe114f89163d9236ec1f4e85eb51b3a7e9f67c4561f39R3-R9) [[2]](diffhunk://#diff-b62375164edd30877d1fe114f89163d9236ec1f4e85eb51b3a7e9f67c4561f39L16-R22)